### PR TITLE
Filtered Mule-EE dependencies when muleEnterprise is set to false (CE environments)

### DIFF
--- a/src/main/groovy/com/mulesoft/build/MulePlugin.groovy
+++ b/src/main/groovy/com/mulesoft/build/MulePlugin.groovy
@@ -155,13 +155,17 @@ class MulePlugin implements Plugin<Project> {
 
         //get the mule version.
         project.dependencies {
-            providedCompile (
-                    [group: 'org.mule', name: 'mule-core', version: mule.version],
+            def eeDeps = [
                     [group: 'com.mulesoft.muleesb.modules', name: 'mule-module-boot-ee', version: mule.version],
-                    [group: 'org.mule.modules', name: 'mule-module-spring-config', version: mule.version],
                     [group: 'com.mulesoft.muleesb', name: 'mule-core-ee', version: mule.version],
                     [group: 'com.mulesoft.muleesb.modules', name: 'mule-module-data-mapper', version: mule.version],
-                    [group: 'com.mulesoft.muleesb.modules', name: 'mule-module-spring-config-ee', version: mule.version],
+                    [group: 'com.mulesoft.muleesb.modules', name: 'mule-module-spring-config-ee', version: mule.version]
+                ]
+            
+            providedCompile (                    
+                    (mule.muleEnterprise ? eeDeps : []) + 
+                    [group: 'org.mule', name: 'mule-core', version: mule.version],
+                    [group: 'org.mule.modules', name: 'mule-module-spring-config', version: mule.version],
                     [group: 'org.mule.transports', name: 'mule-transport-file', version: mule.version],
                     [group: 'org.mule.transports', name: 'mule-transport-http', version: mule.version],
                     [group: 'org.mule.transports', name: 'mule-transport-jdbc', version: mule.version],


### PR DESCRIPTION
By default, both CE and EE dependencies are used in the build (MulePlugin.groovy/providedCompile). This is not desirable when targeting an CE environment, and at least in my case the CE build doesn't even succeed with those dependencies enabled.

I Noticed that there is a readily available flag (MulePluginExtension.groovy/muleEnterprise) that would seem like a logic way of controlling these dependencies, so I made EE dependencies obey the muleEnterprise setting; when muleEnterprise is set to false, EE dependencies are not included.

B.R.
- Daniel Wellner
