### PR TITLE
Update project name in mule-project.xml if it already exists

### DIFF
--- a/src/main/groovy/com/mulesoft/build/studio/StudioProject.groovy
+++ b/src/main/groovy/com/mulesoft/build/studio/StudioProject.groovy
@@ -53,8 +53,12 @@ class StudioProject {
         projectXml.@runtimeId="org.mule.tooling.server.$runtimeVersion".toString()
 
         //set the correct name
-        projectXml.appendNode {
-            name(project.name)
+        if (projectXml.name.size()) {
+            projectXml.name = project.name
+        } else {
+            projectXml.appendNode {
+                name(project.name)
+            }
         }
 
 

--- a/src/test/groovy/com/mulesoft/build/studio/TestStudioPlugin.groovy
+++ b/src/test/groovy/com/mulesoft/build/studio/TestStudioPlugin.groovy
@@ -78,7 +78,7 @@ class TestStudioPlugin {
 
 
     @Test
-    void testGenerateProyectVersion() {
+    void testGenerateProjectVersion() {
 
         String muleVersion = '3.5.0'
         String newerVersion = '3.5.1'
@@ -144,4 +144,23 @@ class TestStudioPlugin {
 
         assertThat(file, containsString('org.mule.tooling.server.3.5.ee'))
     }
+
+    @Test
+    void testSingleProjectName() {
+        String projectName = 'my-project'
+        MulePluginExtension pluginConfig = new MulePluginExtension()
+        InputStream xmlFileStream = getClass().getResourceAsStream('/mule-project-with-name.xml')
+
+        String tempDir = System.getProperty('java.io.tmpdir')
+        Project studioProject = new ProjectBuilder().withName(projectName).withProjectDir(new File(tempDir)).build();
+        StudioProject project = new StudioProject(project: studioProject, muleConfig: pluginConfig)
+
+        def rootNode = project.generateProjectXml(xmlFileStream)
+
+        StringWriter out = new StringWriter()
+        XmlUtil.serialize(rootNode, out)
+        String xml = out.toString()
+        assertEquals("project name should be updated and appear only once", 1, (xml =~ /<name>my-project<\/name>/).size())
+    }
+
 }

--- a/src/test/resources/mule-project-with-name.xml
+++ b/src/test/resources/mule-project-with-name.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule-project xmlns="http://www.mulesoft.com/tooling/project" schemaVersion="3.5.0.0" runtimeId="org.mule.tooling.server.3.5.2.ee">
+  <name>wrong-project</name>
+</mule-project>


### PR DESCRIPTION
It kept appending a new `<name>` node each time the build was run. Here is what the file looked like after saving `build.gradle` a few times in Anypoint Studio (which triggers an automatic build each time).

```
<?xml version="1.0" encoding="UTF-8"?>
<mule-project xmlns="http://www.mulesoft.com/tooling/project" schemaVersion="3.5.0.0" runtimeId="org.mule.tooling.server.3.5.2.ee">
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
  <name>esb-service-example-v1</name>
</mule-project>
```