### PR TITLE
Allow applying components multiple times

### DIFF
--- a/src/main/groovy/com/mulesoft/build/MulePluginExtension.groovy
+++ b/src/main/groovy/com/mulesoft/build/MulePluginExtension.groovy
@@ -82,7 +82,7 @@ class MulePluginExtension {
      * Processed after the default libs, modules, transports has been configured, this is the preferred way of customizing
      * modules.
      */
-    Closure<Void> components = null
+    List<Closure<Void>> components = []
 
     /**
      * Mule core libraries, this normally should not be modified, if empty after project evaluation, defaults will be
@@ -122,7 +122,7 @@ class MulePluginExtension {
     Set<Map<String, String>> plugins = []
 
     void components(Closure<Void> closure) {
-        this.components = closure
+        this.components << closure
     }
 
 

--- a/src/main/groovy/com/mulesoft/build/dependency/MuleProjectDependenciesConfigurer.groovy
+++ b/src/main/groovy/com/mulesoft/build/dependency/MuleProjectDependenciesConfigurer.groovy
@@ -116,7 +116,9 @@ class MuleProjectDependenciesConfigurer implements DependenciesConfigurer {
         //finally call the closure to finalize the customization of the modules.
         if (mule.components) {
             logger.debug('Executing components closure...')
-            ConfigureUtil.configure(mule.components, mule)
+            mule.components.each {
+                ConfigureUtil.configure(it, mule)
+            }
         } else {
             logger.debug('Components closure not present.')
         }

--- a/src/test/groovy/com/mulesoft/build/dependency/TestDependenciesConfigurer.groovy
+++ b/src/test/groovy/com/mulesoft/build/dependency/TestDependenciesConfigurer.groovy
@@ -69,4 +69,24 @@ class TestDependenciesConfigurer {
 
     }
 
+    @Test
+    public void testMultipleComponentClosures() throws Exception {
+
+        MuleProjectDependenciesConfigurer configurer = new MuleProjectDependenciesConfigurer()
+        MulePluginExtension extension = new MulePluginExtension()
+
+        extension.components {
+            modules += 'ws'
+        }
+
+        extension.components {
+            modules += 'db'
+        }
+
+        configurer.mule = extension
+        configurer.applyDefaults()
+
+        assertThat(extension.modules, hasItem('ws'))
+        assertThat(extension.modules, hasItem('db'))
+    }
 }


### PR DESCRIPTION
_I actually thought this is how `mule.components {}` already works but turns out it was not._

This will come in handy especially when working on multi-project solutions. For example, I have a custom Gradle plugin that applies `mule-gradle-plugin` and sets up some common modules, etc. Each Mule project then applies this custom plugin and adds not so common stuff, say a web service adapter does `mule.components { modules += 'ws' }`.

This way I can still use the default dependencies set by `mule-gradle-plugin` and also can use the nice DSL of `mule.components {}` to add more stuff multiple times.

Current work-around is for me to setup everything directly into the arrays and make sure no one uses `components()` unless it is the last project in the dependency chain.

Obvious backward compatibility issue would be if anyone is touching `mule.components` directly at the moment, e.g. `mule.components = { .. }`.

Do you see any issues with this change? I thought through how this plays out, especially considering ordering of closures when executing. For my scenario at least, this works fairly well since custom plugin closure would apply first and then any closures set by the Mule project itself. Not sure if there is another scenario where this would not work as well?